### PR TITLE
Rebrand the tool as Precision Shell with the executable name presh.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -161,5 +161,5 @@ jobs:
       
       - name: build-test
         run: |
-          podman build -t local/fs-shell-sample --build-arg FLAGS=INCLUDE_ALL_COMMANDS=1 .
-          podman run --rm -t local/fs-shell-sample version
+          podman build -t local/precision-shell-sample --build-arg FLAGS=INCLUDE_ALL_COMMANDS=1 .
+          podman run --rm -t local/precision-shell-sample version

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # Compiled Output
-fs-shell
-fs-shell-debug
+presh
+presh-debug
 *.tar
 local-*
 /out/

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,11 +5,13 @@
 * [ab726d9](ab726d9c58ecc09dbe234cc28484422c69a69bc6)
     * Added argument parser error checking (#10).  With this, the argument parsing routine was rewritten which made the compiled version smaller.  This significantly changes how non `-c` argument parsing is handled now, and it may not be supported for v3.0.
     * Fixed a bug with the `exec` command when the exec call out fails.  Before, the error was ignored.  Added a test to cover this (`exec-not-a-command.sh`).
-* (tbd)
+* [162b1f1](162b1f1ec35ce8d8fcf19e8dbe274ad01b7d8bc8)
     * Adjusted tests to allow "-" on each flag to run only if the flag is not enabled.
     * Marked `REQUIRE_FULL_CMD` as a top-level Makefile flag.  Added tests for this flag, and added it to the version flags report and combination builds.
     * Added `ENVIRO_INPUT` as top-level Makefile flag.  Added it to the version flags report and combination builds.
     * Added environment variable parsing when the `ENVIRO_INPUT` flag is set (#11).
+* (tbd)
+    * Rebranded `fs-shell` as `precision-shell` (presh).
 
 
 ## v2.0.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,8 @@ RUN \
 # ---------------------------------
 # The real image.
 FROM scratch
-LABEL name="local/fs-shell" \
-      version="2.0.1"
+LABEL name="local/precision-shell" \
+      version="3.0.0"
 
 # Set the executable under the file "/bin/sh", so that
 #   docker will use it as the default shell when it encounters
@@ -35,7 +35,7 @@ LABEL name="local/fs-shell" \
 # This also chooses the features to include.  In this case, it's the
 #   all-feature version.
 COPY --from=0 \
-    /opt/code/out/fs-shell \
+    /opt/code/out/precision-shell \
     /bin/sh
 
 ENTRYPOINT ["/bin/sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ LABEL name="local/precision-shell" \
 # This also chooses the features to include.  In this case, it's the
 #   all-feature version.
 COPY --from=0 \
-    /opt/code/out/precision-shell \
+    /opt/code/out/presh \
     /bin/sh
 
 ENTRYPOINT ["/bin/sh"]

--- a/Makefile.command-flags
+++ b/Makefile.command-flags
@@ -1,4 +1,4 @@
-# Definition for which commands to include in fs-shell
+# Definition for which commands to include in presh
 COMMAND_FLAGS =
 
 # This is a complete list of command names and the flags that trigger them.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# fs-shell
+# Precision Shell (presh)
 
-[![Build](https://github.com/groboclown/fs-shell/actions/workflows/build.yml/badge.svg)](https://github.com/groboclown/fs-shell/actions/workflows/build.yml)
+[![Build](https://github.com/groboclown/pre-shell/actions/workflows/build.yml/badge.svg)](https://github.com/groboclown/pre-shell/actions/workflows/build.yml)
 
-Minimal file manipulation shell for Linux.
+## Custom Built Shell With Only What You Need
 
-Sometimes, you just don't need a shell.  You just need minimal file system operations.
+Sometimes, you don't need or want a full fledged shell.  You just have a few things that you need to do, and allowing more is a security issue.
 
-`fs-shell` offers a [few commands](#what-it-does), and gives you the flexibility to select which ones to compile, which can make the executable smaller and provide extra security by not enabling commands that don't need to be run.
+`presh` offers a [few commands and shell syntax](#what-it-does), and gives you the flexibility to select which ones to compile, which can make the executable smaller and provide extra security by not enabling commands that don't need to be run.
 
 The tool has two goals - provide just enough commands for what you need to do, and make it small.
 
@@ -21,17 +21,17 @@ Last build size:
   * glibc: 819,656 bytes
   * glibc (Arch): 778,280 bytes
   * musl (Alpine): 21,944 bytes
-  * dietlibc (Alpine): 13,256 bytes
+  * dietlibc (Alpine): 17,352 bytes
 * Standard buld:
   * glibc (Ubuntu): 831,944 bytes
   * glibc (Arch): 782,376 bytes
-  * musl (Alpine): 26,048 bytes
-  * dietlibc (Alpine): 17,424 bytes
+  * musl (Alpine): 26,040 bytes
+  * dietlibc (Alpine): 17,352 bytes
 * Full build:
   * glibc (Ubuntu): 831,944 bytes
-  * glibc (Arch): 782,376 bytes
-  * musl (Alpine): 26,048 bytes
-  * dietlibc (Alpine): 17,424 bytes
+  * glibc (Arch): 786,472 bytes
+  * musl (Alpine): 30,136 bytes
+  * dietlibc (Alpine): 21,448 bytes
 
 *dietlibc [requires](https://www.fefe.de/dietlibc/FAQ.txt) that you either not distribute the compiled executable, or release the executable under GPL v2.*
 
@@ -42,13 +42,14 @@ These file sizes are *statically compiled*, so they don't have any external depe
 
 The shell supports these commands:
 
-* [version](#version) - prints the current version.
+* [version](#version) - prints the current version (cannot be disabled).
 * [noop](#noop) - do nothing.
 * [echo](#echo) - send text to `stdout`.
 * [fmode](#fmode) - set the octal file mode for other commands.
 * [rm](#rm) - remove files.
 * [rmdir](#rmdir) - remove empty directories.
 * [mv](#mv) - move a file from one name to another.
+* [fmode](#fmode) - set a default file permission.
 * [mkdir](#mkdir) - create an empty directory.
 * [chmod](#chmod) - change file permissions.
 * [chown](#chown) - change user and group owner for files.
@@ -64,19 +65,18 @@ The shell supports these commands:
 * [exec](#exec) - switch execution to a new process.
 
 It also supports:
-* [Chaining commands](#command-chaining) together with `&&` and `;`.
-* [Standard script argument flag](#standard-script-flag) - if passed with the arguments `-c "commands"`, then the shell will parse the commands argument into individual commands.
-
-If the streaming input flag is enabled, then the tool also supports:
+* [Chaining commands](#command-chaining) together with `&&` and `;` (cannot be disabled).
+* [Standard script argument flag](#standard-script-flag) - if passed with the arguments `-c "commands"`, then the shell will parse the commands argument into individual commands (cannot be disabled).
 * [Script files](#script-files) - as an argument if used with `-f script-file-name`.
 * [Commands from stdin](#passing-commands-from-stdin) - With the `-` argument, commands are parsed from stdin.  **Without the streaming input flag, the shell will not read from stdin.**
+* [Environment variable parsing](#environment-variables) - the input values can be replaced with environment variables, when specified in the form `${VALUE}` (the standard shell form of `$VALUE` is not supported).
 
-This allows you to use it in Docker or Podman as a default shell, which is useful if you need file modifications to an image that has no shell.
+`presh` works very well for Docker and Podman containers as the default shell, which is useful if you need file modifications to an image that has no shell.
 
 ```Dockerfile
 FROM super-skinny-image:11.12
 
-COPY fs-shell /bin/sh
+COPY presh /bin/sh
 
 # Because /bin/sh is now the shell, run commands will
 #   run through it by executing "/bin/sh -c (arguments)"
@@ -91,25 +91,21 @@ RUN echo Startup \
 
 * List files.
 * Copy files.
-* Modify files.  *With input-enabled builds, files can be truncated and written to.*
-* Alter file contents.
 * Process controls.
 * Report detailed error messages.
 * Change file timestamps.
-* File descriptor redirect.
 * Change current directory.
 * Provide splat pattern replacements.
-* Use environment variables.
+* Alter environment variables.
 * Flow control (if logic and loops) outside of early exit due to prior errors.
 * Background jobs or job control.
-* Allow for interactive execution.
 * Anything with the network.
 * Tell you how to use it.  That's what this document is for.
 
 
 ## Why Would I Need It?
 
-The tool was built with Docker images that use minimal OS resources.  If something like Busybox is too big for you, but you need some simple file manipulation because you built upon another image, then this is right for you.
+The tool was built with container (Docker and Podman) images that use minimal OS resources.  Golang projects commonly build a single file, the executable, placed into a `FROM scratch` image.  In these environments, `presh` can be easily added to provide some minimal file manipulation.
 
 Additionally, you can build the tool with exactly the commands you need to run.  This limits the attack surface, making your install just that much safer.
 
@@ -146,63 +142,104 @@ To run the build, you'll need basic C compiler, linker, and make.  If you have P
 The most common setup is to build it inside a Docker container for use in another container.  See [`Dockerfile`](Dockerfile) for how this is done.
 
 
-## What Does It Mean?
-
-The "fs" in `fs-shell` can mean:
-
-* "FROM scratch", because it's useful in Docker images that come from the scratch image (e.g. no OS files).
-* "File System", because it only works with file system operations.
-* "Functionally Simple", because it's easy on the features.  It's the opposite of "Feature Rich".
-* "Freakin' Stupid", because it does so little.
-
-
 ## Help
+
+All commands and special build modes are described here.  To add in a compile flag, run the build like: `make COMMAND_FLAGS="-DUSE_CMD_ECHO -DUSE_CMD_RM"`
+
 
 ### version
 
-Usage: `version`
+**Compile flag**: *always present*
+
+**Usage**: `version`
 
 Prints the version information to stdout.  Any additional arguments generates an error.
 
 ### noop
 
-Usage: `noop [arg1 [arg2 ...]]`
+**Compile flag**: `-DUSE_CMD_NOOP`
+
+**Usage**: `noop [arg1 [arg2 ...]]`
+
 
 Does nothing and ignores all arguments after it.
 
 ### echo
 
-Usage: `echo [str1 [str2 ...]]`
+**Compile flag**: `-DUSE_CMD_ECHO`
 
-Sends to `stdout` each argument, one per line.  To have a multi-word statement on a single line, it must be passed as a single argument.
+**Usage**: `echo [str1 [str2 ...]]`
+
+Sends to `stdout` each argument, one per line.  To have a multi-word statement on a single line, it must be passed as a single argument; see (Command Parsing)[#command-parsing] for details.
 
 ### rm
 
-Usage: `rm [file1 [file2 ...]]`
+**Compile flag**: `-DUSE_CMD_RM`
+
+**Usage**: `rm [file1 [file2 ...]]`
 
 Removes each file passed as an argument.  The command will attempt to remove each file, and if any of them fail, then the whole command fails with an exit code equal to the sum of the error codes.
 
 ### rmdir
 
-Usage: `rmdir [dir1 [dir2 ...]]`
+**Compile flag**: `-DUSE_CMD_RMDIR`
+
+**Usage**: `rmdir [dir1 [dir2 ...]]`
 
 Removes each empty directory passed as an argument.  If a directory is not empty, the command will fail.  The command will attempt to remove each directory, and if any of them fail, then the whole command fails with an exit code equal to the sum of the number of failed files.
 
 ### mv
 
-Usage: `mv (src file) (target file)`
+**Compile flag**: `-DUSE_CMD_MV`
+
+**Usage**: `mv (src file) (target file)`
 
 Renames the file referenced by the first argument to a new name referenced by the second argument.  If the operation fails, or if there is no second argument, then the command fails with an exit code of 1.
 
+### fmode
+
+**Compile flag**: *included automatically if the dependent commands are included; see below*
+
+**Usage**: `fmode (octal mode)`
+
+Changes an internal default file mode value to the given octal mode.  If never set, the default file mode value is `0644`.
+
+Example:
+
+```bash
+$ presh -c "fmode 765 ; touch a.txt"
+$ ls -l a.txt
+-rwxrw-r-x 1 user user   0 Jan 19 09:51 a.txt 
+```
+
+This can include the higher bits, too, so that some commands that support it (and if the executing user has permissions to run it) can set the sticky bits.
+
+This command is added if any of these commands are added through compile flags, and they will in turn use this mode when working with files.
+
+* [`mkdir`](#mkdir)
+* [`touch`](#touch)
+* [`trunc`](#trunc)
+* [`mknod`](#mknod)
+* [`mkdev`](#mkdev)
+* [`dup-a`](#dup-a)
+* [`dup-r`](#dup-r)
+* [`dup-w`](#dup-w)
+
 ### mkdir
 
-Usage: `mkdir (octal mode) [file1 [file2 ...]]`
+**Compile flag**: `-DUSE_CMD_MKDIR`
 
-Creates the listed directories with the permissions of the first argument.  The parent directory must exist, or it will generate an error.  If any creation fails, then the command fails with the number of failed directories.
+**Usage**: `mkdir [file1 [file2 ...]]`
+
+Creates the listed directories.  The parent directory must exist, or it will generate an error.  If any creation fails, then the command fails with the number of failed directories.
+
+Each directory is created with the global file mode (see [`fmode`](#fmode)), with the user, group, and other executable flags also set.  To change this to something else, a [`chmod`](#chmod) must be run.
 
 ### chmod
 
-Usage: `chmod (octal mode) [file1 [file2 ...]]`
+**Compile flag**: `-DUSE_CMD_CHMOD`
+
+**Usage**: `chmod (octal mode) [file1 [file2 ...]]`
 
 Changes the file permissions for each file or directory.  The mode must be passed as an octal number.
 
@@ -213,7 +250,7 @@ $ touch a.txt
 $ chmod 600 a.txt
 $ ls -l a.txt
 -rw------- 1 user user   0 Jan 19 09:51 a.txt
-$ fs-shell 770 a.txt
+$ presh -c "chmod 770 a.txt"
 $ ls -l a.txt
 -rwxrwx--- 1 user user   0 Jan 19 09:51 a.txt
 ```
@@ -222,40 +259,54 @@ This command will fail if the mode value is out of range or not a number.
 
 ### chown
 
-Usage: `chown (uid) (gid) [file1 [file2 ...]]`
+**Compile flag**: `-DUSE_CMD_MKDIR`
+
+**Usage**: `chown (uid) (gid) [file1 [file2 ...]]`
 
 Changes the owner and group ID for each file, directory, or symlink argument.
 
 ### ln-s
 
-Usage: `ln-s (src file) (dest file)`
+**Compile flag**: `-DUSE_CMD_LN_S`
+
+**Usage**: `ln-s (src file) (dest file)`
 
 Creates a symbolic link named dest file, pointing to src file.
 
 ### ln-h
 
-Usage: `ln-h (src file) (dest file)`
+**Compile flag**: `-DUSE_CMD_LN_H`
+
+**Usage**: `ln-h (src file) (dest file)`
 
 Creates a hard link named dest file, pointing to src file.
 
 ### sleep
 
-Usage: `sleep [seconds [seconds ...]]`
+**Compile flag**: `-DUSE_CMD_SLEEP`
+
+**Usage**: `sleep [seconds [seconds ...]]`
 
 Sleeps for the number of seconds in the argument.  If no arguments are given, or if an argument is not a positive integer, then it does nothing (no error).  If multiple, positive integers are given, then it sleeps for the sum of them.
 
 ### mknod
 
-Usage: `mknod (node type) [file1 [file2 ...]]`
+**Compile flag**: `-DUSE_CMD_MKNOD`
+
+**Usage**: `mknod (node type) [file1 [file2 ...]]`
 
 Creates a special or ordinary file of the given type.  The node type is OS specific, but in general, the values supported are:
 
 * `p` - pipe (FIFO queue)
 * `s` - UNIX domain socket
 
+The created file will have the file permissions set in [`fmode`](#fmode).
+
 ### mkdev
 
-Usage: `mkdev (major version) (minor version) (node type) [file1 [file2 ...]]`
+**Compile flag**: `-DUSE_CMD_MKDEV`
+
+**Usage**: `mkdev (major version) (minor version) (node type) [file1 [file2 ...]]`
 
 The node type can be one of these:
 
@@ -267,36 +318,50 @@ The major and minor version reflect the OS kernel specific device number.
 For example, to create the standard `/dev/null` device, you would run:
 
 ```bash
-fs-shell mkdev c 1 3 /dev/null
+presh mkdev c 1 3 /dev/null
 ```
+
+The created file will have the file permissions set in [`fmode`](#fmode).
 
 The execution of this command requires running with root level privileges, or the tool will report an error.
 
 ### touch
 
-Usage: `touch [file1 [file2 ...]]`
+**Compile flag**: `-DUSE_CMD_TOUCH`
+
+**Usage**: `touch [file1 [file2 ...]]`
 
 For each argument, if it does not exist, it is created.  If the argument exists and is not a file, then the command fails.  **Warning:** Unlike the standard `touch` command, this will not update the modified time of the file.
 
+If this creates a file, the file will have the file permissions set in [`fmode`](#fmode).
+
 ### trunc
 
-Usage: `trunc [file1 [file2 ...]]`
+**Compile flag**: `-DUSE_CMD_TRUNC`
+
+**Usage**: `trunc [file1 [file2 ...]]`
 
 For each argument, sets the file length to 0 if the file exists, otherwise creates the file.  This is nearly identical to [touch](#touch), with the addition of setting file lengths to 0.
 
+If this creates a file, the file will have the file permissions set in [`fmode`](#fmode).
+
 ### dup-r, dup-w, dup-a
 
-Usage: `dup-w (fd) (file)`
+**Compile flag**: `-DUSE_CMD_DUP_W` and `-DUSE_CMD_DUP_R` and `-DUSE_CMD_DUP_A`
 
-Usage: `dup-r (fd) (file)`
+**Usage**: `dup-w (fd) (file)`
 
-Usage: `dup-a (fd) (file)`
+**Usage**: `dup-r (fd) (file)`
+
+**Usage**: `dup-a (fd) (file)`
 
 Opens the given file in either write + truncate mode (`dup-w`), write + append mode (`dup-a`), or read mode (`dup-r`), then duplicates that file descriptor to the "fd" argument.  This duplication remains in effect for the remainder of the execution, or until another `dup` command runs for the same file descriptor.
 
 This is the equivalent of running a command like `echo > out.txt` to redirect stdout, stderr, or stdin to a file.
 
 You can also use the special files "&1" and "&2" to redirect stdout or stderr, respectively, to the file descriptor.  See examples for interesting usages.
+
+If this creates a file, the file will have the file permissions set in [`fmode`](#fmode).
 
 Note that this cannot be used for redirecting output from one command into another; that requires FIFO queues and job control, which this shell doesn't support.
 
@@ -306,7 +371,7 @@ Run `echo` with output sent to the file `here.txt`, appending existing text.
 
 ```bash
 echo -n "foo" > here.txt
-fs-shell -c "dup-a 1 here.txt && echo ' bar text' && echo more text"
+presh -c "dup-a 1 here.txt && echo ' bar text' && echo more text"
 ```
 
 And the file `here.txt` will contain:
@@ -323,7 +388,7 @@ Run `echo` with output sent to stderr
 
 ```bash
 # These are equivalent
-fs-shell -c "dup-w 1 &2 && echo hello"
+presh -c "dup-w 1 &2 && echo hello"
 bash -c "echo hello 1>&2"
 ```
 
@@ -333,7 +398,7 @@ Run `find` command with stdout redirected to file `out.txt` and stderr redirecte
 
 ```bash
 # These are equivalent
-fs-shell -c "dup-w 1 out.txt && dup-w 2 err.txt && exec /usr/sbin/find /var -type f"
+presh -c "dup-w 1 out.txt && dup-w 2 err.txt && exec /usr/sbin/find /var -type f"
 bash -c "find /var -type f >out.txt 2>err.txt"
 ```
 
@@ -342,7 +407,7 @@ bash -c "find /var -type f >out.txt 2>err.txt"
 Generate some text to a file named `contents.txt`, then and sort it into another file named `sorted.txt`.
 
 ```bash
-fs-shell -c "dup-w 1 contents.txt \
+presh -c "dup-w 1 contents.txt \
     && echo foo bar baz \
     && dup-w 1 sorted.txt \
     && dup-r 0 contents.txt \
@@ -352,14 +417,16 @@ fs-shell -c "dup-w 1 contents.txt \
 
 ### signal-wait
 
-Usage: `signal [signal1 [signal2]] [wait]`
+**Compile flag**: `-DUSE_CMD_SIGNAL`
+
+**Usage**: `signal [signal1 [signal2]] [wait]`
 
 Waits for any of the OS signal number arguments before continuing.  If no signal is given (just `signal wait`), then it waits for a standard OS interruption, which will kill the whole process.
 
 Of note, once a signal is added to the list, it is registered for standard OS ignoring.  Only by adding the statement `wait` will the processing wait for the signal to be raised.  This can be used for interesting applications, such as:
 
 ```bash
-fs-shell -c "signal 2 ; signal 15 wait"
+presh -c "signal 2 ; signal 15 wait"
 ```
 
 This will cause the shell to ignore SIGINT (2, usually sent by a ctrl-c input), and wait for SIGTERM (15).
@@ -368,61 +435,95 @@ This will cause the shell to ignore SIGINT (2, usually sent by a ctrl-c input), 
 
 ### exec
 
-Usage: `exec (cmd) [arg1 [arg2 ...]]`
+**Compile flag**: `-DUSE_CMD_TRUNC`
+
+**Usage**: `exec (cmd) [arg1 [arg2 ...]]`
 
 Reads the remaining arguments (even `;` and `&&`, thus it ignores command chaining), and replaces the current process with the new one.  If the command argument is not given, then this fails.
 
-Commands must be given in the full path; it doesn't look at any environment variable like `PATH`.
+Commands must be given in the full path; it doesn't look at any environment variable like `PATH`, even with the [environment variable parsing](#environment-variables) enabled.
 
 ### Chaining Commands
 
-Like most shells, you can chain commands together with `&&` and `;`.  `&&` stops the execution if the previous command failed and allows another command after it; and `;` resets the error count to 0 and allows another command to follow it.
+Like most shells, you can chain commands together with `&&` and `;`.  `&&` stops the execution if the previous command failed and allows another command after it; and `;` resets the error count to 0 and allows another command to follow it.  If a new line is encountered, that acts like a `;`.
 
 ```bash
 $ ls
-fs-shell
-$ ./fs-shell -c "echo abc && rmdir does-not-exist ; echo dce"
+presh
+$ ./presh -c "echo abc && rmdir does-not-exist ; echo dce"
 abc
 ERROR rmdir: does-not-exist
 dce
-$ ./fs-shell -c "echo abc && rmdir does-not-exist && echo dce"
+$ ./presh -c "echo abc && rmdir does-not-exist && echo dce"
 abc
 ERROR rmdir: does-not-exist
 FAIL &&
+$ ./presh -c "echo abc \
+echo def"
+abc
+def
 ```
 
 The `exec` command, however, ignores the chain, and passes all arguments to the requested command:
 
 ```bash
-$ ./fs-shell -c "echo abc ; echo def"
+$ ./presh -c "echo abc ; echo def"
 abc
 def
 # Use the "which" command to find where the echo command is located
 # on the path.  Some systems have this under /usr/sbin/echo.
-$ ./fs-shell -c "$( which echo ) abc ; echo def"
+$ ./presh -c "$( which echo ) abc ; echo def"
 ERROR /usr/sbin/echo: abc
 def
-$ ./fs-shell -c "exec $( which echo ) abc ; echo def"
+$ ./presh -c "exec $( which echo ) abc ; echo def"
 abc ; echo def
 ```
 
+### Environment Variables
+
+**Compile flag**: `-DUSE_ENVIROMENT_INPUT`
+
+With environment variable parsing enabled, argument parsing will replace text in the form `${VALUE}` with the environment variable contained in the `${}` marks.  Currently, these are not expanded into multiple arguments, but instead will be considered part of a single argument.  Because the [`echo`](#echo) command outputs one argument per line, this shows the behavior clearly:
+
+```bash
+$ echo "echo \${ABC} \${ABC}" > script.txt
+$ cat script.txt
+echo ${ABC} ${ABC}
+$ export ABC="a b c"
+$ ./presh -f script.txt
+a b c
+a b c
+```
 
 ### Standard Script Flag
 
 The tool also supports invoking it with the arguments `-c "commands"` to simulate running the second argument as a script.
 
+### Command Parsing
+
 The parsing is kept simple, and follows these rules:
 
 * A space character (` `), tab, and linefeed (`\r`) separates arguments.
-* Unix-style newlines (`\n`) are treated like inserting a `;` between commands.
+* The parser will handle newlines (`\n`) differently depending on whether you use an input-enabled build or not.  With an input-enabled build, newlines are treated like inserting a `;` between commands, whereas a non-input-enabled build treats newlines like a space.
 * Pairs of quote characters (`"` and `'`) can encapsulate text, allowing space characters and other quote characters to be part of an argument, rather than separating arguments.
 * Characters can be escaped by adding a backslash (`\`) character.  `\n` turns into a newline, `\r` into a linefeed, `\t` into a tab, and anything else is the character itself.  This is how quote characters can be added, as well as an alternate to adding a space to an argument.
 
-
 ### Script Files
 
-If you use the input-enabled build, then you can pass the arguments `-f script-file-name` to run that file as a set of commands.
+**Compile flag**: `-DUSE_STREAMING_INPUT`
 
+If you use the input-enabled build, then you can use these additional forms of the command:
+
+* `presh -f script-file.txt`
+  runs the commands contained in the file `script-file.txt`
+* `presh -`
+  reads commands from stdin.
+
+### Better Error Reporting
+
+**Compile flag**: `-DREQUIRE_FULL_CMD`
+
+Some commands, like [`ln-s`](#ln-s), require an exact number of arguments.  Unless this flag is set, using the command with just one argument will not cause a failure.  With this flag, `presh` will generate an error.
 
 ### Passing Commands from stdin
 
@@ -448,10 +549,10 @@ To build through Docker and capture the built executables:
 ```bash
 mkdir -p out
 for libname in glibc musl ; do
-    docker build -t local/fs-shell-${libname} -f build-${libname}.Dockerfile .
-    container=$( docker create local/fs-shell-${libname} )
-    docker cp "${container}:/opt/code/out/fs-shell" out/fs-shell.${libname}
-    docker cp "${container}:/opt/code/out/fs-shell-debug" out/fs-shell-debug.${libname}
+    docker build -t local/presh-${libname} -f build-${libname}.Dockerfile .
+    container=$( docker create local/presh-${libname} )
+    docker cp "${container}:/opt/code/out/presh" out/presh.${libname}
+    docker cp "${container}:/opt/code/out/presh-debug" out/presh-debug.${libname}
     docker rm "${container}"
 done
 ```
@@ -462,7 +563,7 @@ To enable different commands in the compiled executable from the Docker build, r
 
 ```bash
 docker build \
-  -t local/fs-shell-${libname} -f build-${libname}.Dockerfile \
+  -t local/presh-${libname} -f build-${libname}.Dockerfile \
   --build-arg COMMANDS="rm rmdir chmod chown"
   .
 ```
@@ -470,8 +571,8 @@ docker build \
 Additionally, for your own purposes, you can build it against the "dietlibc" library.  However, this has special considerations in that it's GPL v2, and [you can't distribute the binary under this program's MIT license](http://www.fefe.de/dietlibc/FAQ.txt).
 
 ```bash
-docker build -t local/fs-shell-dietlibc -f build-dietlibc.Dockerfile . \
-    && ./extract-executables.sh local/fs-shell-dietlibc -o out -s .dietlibc -d
+docker build -t local/presh-dietlibc -f build-dietlibc.Dockerfile . \
+    && ./extract-executables.sh local/presh-dietlibc -o out -s .dietlibc -d
 ```
 
 To bump the version number, change the [version.txt](version.txt) file.  Version numbers must be in a dewey decimal format MAJOR.MINOR.PATCH (e.g. `1.2.3`).
@@ -505,6 +606,6 @@ Releases should:
 
 ## License
 
-fs-shell is licensed under the [MIT license](LICENSE).
+Precision Shell is licensed under the [MIT license](LICENSE).
 
 Depending on how you compile the executable, the executable may be under a different license.  For example, compiling with the `dietlibc` library causes the compiled executable to be under GPL 2.0.

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,6 @@
 # Planning Board
 
-Here's what's planned for the future of the tool.  Because of the backwards compatibility issues, this will be a major version bump.  With that, the tool will be renamed to "Precision Shell", because the Hadoop system has a "file system shell" that makes searching for `fs-shell` hard.
+Here's what's planned for the future of the tool.  Because of the backwards compatibility issues, this will be a major version bump.
 
 
 ## Change Argument Quoting
@@ -20,3 +20,15 @@ The special command `(` will cause the shell to enter a sub-command, allowing fo
 ## Command Line Arguments
 
 Historically, arguments were used as-is, assuming the calling program already parsed them.  Starting with v3, the parsing algorithm significantly changed to support the much more common use case of "-c" argument parsing.  This raises the question if the old command line parsing should be maintained?  No other major shell supports this execution mode.
+
+
+## Fix signal-ignore-wait
+
+Issue #18
+
+On musl, this test fails often with 
+
+```
+kill: can't kill pid 3110: No such process
+Did not stay alive on wait (2).
+```

--- a/build-tools/cmd-sizes.sh
+++ b/build-tools/cmd-sizes.sh
@@ -27,13 +27,13 @@ while [ $i -lt ${set_count} ] ; do
     name="${command_set_names[$i]}"
     cmds="${command_sets[$i]}"
     # echo "$i : ${name} - ${cmds}"
-    outdir=/tmp/fs-shell-$$
+    outdir=/tmp/presh-$$
     mkdir -p "${outdir}"
     ( cd "../src" && make src "${cmds}" OUTDIR="${outdir}" >/dev/null 2>&1 )
-    if [ $? != 0 ] || [ ! -f "${outdir}/fs-shell" ] ; then
+    if [ $? != 0 ] || [ ! -f "${outdir}/presh" ] ; then
         echo "Build failed for: make src ${cmds} OUTDIR=${outdir}" >&2
     else
-        filesize=$( wc -c <"${outdir}/fs-shell" )
+        filesize=$( wc -c <"${outdir}/presh" )
         echo "${filesize}|${name}" >> "${sizefile}"
         # echo "${filesize} < ${name}"
     fi

--- a/build-tools/combinatorics-test.sh
+++ b/build-tools/combinatorics-test.sh
@@ -50,7 +50,7 @@ while [ ${running} = 1 ] ; do
     echo "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
     echo "${cmdarg}"
 
-    mkout=/tmp/fs-shell-$$.txt
+    mkout=/tmp/presh-$$.txt
     ( cd ../src && make "${cmdarg}" >"${mkout}" 2>&1 )
     if [ $? != 0 ] ; then
         # compile failure is just bad

--- a/build-tools/generate-command-template.py
+++ b/build-tools/generate-command-template.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 
 # Instead of using m4, which is everywhere but horribly tricky to use,
-# we have our own template language.
+# we have our own template language.  This means no tooling support!  Yay!
 
 from typing import List, Sequence, Dict, Optional
 import os

--- a/build-tools/individual-cmds.sh
+++ b/build-tools/individual-cmds.sh
@@ -29,7 +29,7 @@ command_list=(${command_list_raw})
 
 echo "Complete command variation list: ${command_list[@]} + ${streaming_arg}"
 
-bindir=/tmp/fs-shell-bin-$$
+bindir=/tmp/presh-bin-$$
 mkdir -p "${bindir}"
 failures=/tmp/failures-$$.txt
 touch "${failures}"
@@ -39,12 +39,12 @@ for cmd in "${command_list[@]}" ; do
     cmd_name=$( echo "${cmd_name}" | tr '[:upper:]' '[:lower:]' | tr _ - )
     flag_index=0
     while [ ${flag_index} -lt ${extra_flag_count} ] ; do
-        exe_name="fs-shell-${cmd_name}${extra_name_combos[${flag_index}]}"
+        exe_name="presh-${cmd_name}${extra_name_combos[${flag_index}]}"
         cmdarg="COMMAND_FLAGS=${cmd} ${extra_flag_combos[${flag_index}]}"
         echo "${cmdarg}"
         flag_index=$(( flag_index + 1 ))
 
-        mkout=/tmp/fs-shell-$$.txt
+        mkout=/tmp/presh-$$.txt
         ( cd ../src && make "${cmdarg}" >"${mkout}" 2>&1 )
         if [ $? != 0 ] ; then
             # compile failure is just bad
@@ -54,17 +54,17 @@ for cmd in "${command_list[@]}" ; do
             rm "${mkout}"
             exit 1
         fi
-        cp ../out/fs-shell "${bindir}/${exe_name}"
+        cp ../out/presh "${bindir}/${exe_name}"
         rm "${mkout}"
         touch "${mkout}"
 
         # could also check if +input is in version...
 
-        ../out/fs-shell version | grep " +${cmd_name}" >/dev/null 2>&1
+        ../out/presh version | grep " +${cmd_name}" >/dev/null 2>&1
         if [ $? != 0 ]; then
             echo "===================================================" >> "${failures}"
             echo "${cmdarg}" >> "${failures}"
-            ../out/fs-shell version >> "${failures}"
+            ../out/presh version >> "${failures}"
             echo "No command flag '${cmd_name}' in version listed." >> "${failures}"
         else
             echo "===================================================" > "${mkout}"

--- a/build-tools/internal-docker-make.sh
+++ b/build-tools/internal-docker-make.sh
@@ -15,7 +15,7 @@ case "${BUILD_MODE}" in
         ;;
     src)
         ( cd src && make src )
-        ls -lA out/fs-shell*
+        ls -lA out/presh*
         ;;
     combinatorics-test)
         build-tools/combinatorics-test.sh
@@ -26,33 +26,33 @@ case "${BUILD_MODE}" in
     combos)
         mkdir -p .tmp/combos
         make src tests || echo "Tests failed"
-        cp out/fs-shell .tmp/combos/fs-shell-zero
-        cp out/fs-shell-debug .tmp/combos/fs-shell-zero-debug
+        cp out/presh .tmp/combos/presh-zero
+        cp out/presh-debug .tmp/combos/presh-zero-debug
 
         make INCLUDE_ALL_COMMANDS=1 src tests || echo "Tests failed"
-        cp out/fs-shell .tmp/combos/fs-shell-all
-        cp out/fs-shell-debug .tmp/combos/fs-shell-all-debug
+        cp out/presh .tmp/combos/presh-all
+        cp out/presh-debug .tmp/combos/presh-all-debug
 
         make INCLUDE_MINIMAL_COMMANDS=1 src tests || echo "Tests failed"
-        cp out/fs-shell .tmp/combos/fs-shell-min
-        cp out/fs-shell-debug .tmp/combos/fs-shell-min-debug
+        cp out/presh .tmp/combos/presh-min
+        cp out/presh-debug .tmp/combos/presh-min-debug
 
         make INCLUDE_STANDARD_COMMANDS=1 src tests || echo "Tests failed"
-        cp out/fs-shell .tmp/combos/fs-shell-std
-        cp out/fs-shell-debug .tmp/combos/fs-shell-std-debug
+        cp out/presh .tmp/combos/presh-std
+        cp out/presh-debug .tmp/combos/presh-std-debug
 
         cp .tmp/combos/* out/.
 
-        echo "fs-shell-zero" > out/build-inventory.txt
-        echo "fs-shell-zero-debug" >> out/build-inventory.txt
-        echo "fs-shell-all" >> out/build-inventory.txt
-        echo "fs-shell-all-debug" >> out/build-inventory.txt
-        echo "fs-shell-min" >> out/build-inventory.txt
-        echo "fs-shell-min-debug" >> out/build-inventory.txt
-        echo "fs-shell-std" >> out/build-inventory.txt
-        echo "fs-shell-std-debug" >> out/build-inventory.txt
+        echo "presh-zero" > out/build-inventory.txt
+        echo "presh-zero-debug" >> out/build-inventory.txt
+        echo "presh-all" >> out/build-inventory.txt
+        echo "presh-all-debug" >> out/build-inventory.txt
+        echo "presh-min" >> out/build-inventory.txt
+        echo "presh-min-debug" >> out/build-inventory.txt
+        echo "presh-std" >> out/build-inventory.txt
+        echo "presh-std-debug" >> out/build-inventory.txt
 
-        ls -lAS out/fs-shell*
+        ls -lAS out/presh*
         ;;
     *)
         commands=""
@@ -79,6 +79,6 @@ case "${BUILD_MODE}" in
         fi
         echo "make \"${cmdarg}\" all"
         make "${cmdarg}" all
-        ls -lAS out/fs-shell*
+        ls -lAS out/presh*
         ;;
 esac

--- a/build-tools/size-check/compile-flag-sizes.sh
+++ b/build-tools/size-check/compile-flag-sizes.sh
@@ -49,7 +49,7 @@ all_flags=(
 # First pass is to find which flags cause a failure.  Don't include these
 #   in our list to try
 valid_flags=()
-tmpout=/tmp/fs-shell-$$
+tmpout=/tmp/presh-$$
 for val in "${all_flags[@]}" ; do
     echo "Trying ${val}"
     ( cd "../../src" && make src MINFLAGS="${val}" OUTDIR="${tmpout}" )

--- a/build-tools/size-check/gather-compile-size.sh
+++ b/build-tools/size-check/gather-compile-size.sh
@@ -16,13 +16,13 @@ fi
 # Test compilation to get the smallest size possible.
 
 
-outdir=/tmp/fs-shell-$$
+outdir=/tmp/presh-$$
 mkdir -p "${outdir}"
 ( cd "$( dirname "$0" )/../../src" && make src MINFLAGS="${minflags}" "${COMMAND_FLAGS}" OUTDIR="${outdir}" >/dev/null 2>&1 )
-if [ $? != 0 ] || [ ! -f "${outdir}/fs-shell" ] ; then
+if [ $? != 0 ] || [ ! -f "${outdir}/presh" ] ; then
     echo "${minflags}" >> "${badfile}"
 else
-    filesize=$( wc -c <"${outdir}/fs-shell" )
+    filesize=$( wc -c <"${outdir}/presh" )
     rm -r "${outdir}"
     echo "${filesize}|${minflags}|${COMMAND_FLAGS}" >> "${sizefile}"
     echo "${filesize} < ${minflags}"

--- a/sample.Dockerfile
+++ b/sample.Dockerfile
@@ -1,4 +1,4 @@
-# Builds the fs-shell tool in one container, then adds that built version into the
+# Builds the precision shell tool in one container, then adds that built version into the
 # derived container.  This uses the musl library.
 FROM docker.io/library/alpine:3.10 AS builder
 WORKDIR /opt/code
@@ -19,15 +19,15 @@ RUN \
        apk --no-cache update \
     && apk add build-base=0.5-r1 "bash=~5" "python3=~3.7" git \
     && rm -rf /tmp/* /var/cache/apk/* \
-    && git clone https://github.com/groboclown/fs-shell.git /opt/code/fs-shell \
-    && cd /opt/code/fs-shell \
+    && git clone https://github.com/groboclown/precision-shell.git /opt/code/precision-shell \
+    && cd /opt/code/precision-shell \
     && echo 'LIBNAME=musl' >> version.txt \
     && ./build-tools/internal-docker-make.sh
 
 
 # The real image, using what was just built.
 FROM scratch
-LABEL name="local/fs-shell-example"
+LABEL name="local/precision-shell-example"
 
 # Copy the image built above and set it as the shell.
-COPY --from=builder /opt/code/fs-shell/out/fs-shell /bin/sh
+COPY --from=builder /opt/code/precision-shell/out/presh /bin/sh

--- a/size-experiments.md
+++ b/size-experiments.md
@@ -6,7 +6,7 @@ For this tool, three different implementations were created:
 * **table-case**: command names are stored in a table, which are looped over to perform comparison for the assigned command integer.  This integer is then used for a case statement when first discovered (only a few commands are in this case), and also for each argument to the command.
 * **table**: all command names and execution functions are stored in tables.  Commands are implemented in separate functions.
 
-Each of these commands can be found in the `v2` branch of the code.
+Each of these commands can be found in the `v2` branch of the code.  Note that this branch still uses the old branding, where the tool is called `fs-shell`.
 
 The implementations were compiled against the glibc, musl, and dietlibc libraries using four different command sets, as defined in the `Makefile.command-flags` file ("zero" being a version built with only the `version` command, which cannot be turned off).
 
@@ -62,7 +62,7 @@ Because the table-case setup is the most efficient from a size perspective, but 
 
 ## Results
 
-`fs-shell` philosophy primarily focuses on *just enough functionality*.  File size is secondary.
+`presh` philosophy primarily focuses on *just enough functionality*.  File size is secondary.
 
 Note that the table-func version increases linearly as the number of functions is added, whereas the case statements one increase in blocks, most likely because the case lookup table is aligned in blocks.
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -94,16 +94,16 @@ all: clean src debug
 
 .PHONY: src
 src: \
-	$(OUTDIR)/fs-shell
+	$(OUTDIR)/presh
 
 .PHONY: debug
 debug: \
-	$(OUTDIR)/fs-shell-debug
+	$(OUTDIR)/presh-debug
 
 # Note that the arguments to the rm match the all parameters.
 .PHONY: clean
 clean:
-	rm $(OUTDIR)/fs-shell* $(COMMAND_HEADERS_DIR) 2>/dev/null || echo ""
+	rm $(OUTDIR)/presh* $(COMMAND_HEADERS_DIR) 2>/dev/null || echo ""
 
 .PHONY: all-clean
 all-clean: clean
@@ -134,11 +134,11 @@ $(COMMAND_HEADERS_DIR)/command_list.h: $(COMMANDS)
 		|| $(MKCMDLIST) $(COMMANDS) $*.h
 
 
-$(OUTDIR)/fs-shell: $(SRC) $(COMMAND_HEADERS_DIR)/command_list.h
+$(OUTDIR)/presh: $(SRC) $(COMMAND_HEADERS_DIR)/command_list.h
 	mkdir -p $(OUTDIR)
 	$(CC) $(CFLAGS) $(LFLAGS) $(MINFLAGS) $(COMMAND_FLAGS) $? $(LDFLAGS) -o $@
 
 
-$(OUTDIR)/fs-shell-debug: $(SRC) $(COMMAND_HEADERS_DIR)/command_list.h
+$(OUTDIR)/presh-debug: $(SRC) $(COMMAND_HEADERS_DIR)/command_list.h
 	mkdir -p $(OUTDIR)
 	$(CC) $(CFLAGS) $(LFLAGS) $(DFLAGS) $(COMMAND_FLAGS) $? $(LDFLAGS) -o $@

--- a/src/README.md
+++ b/src/README.md
@@ -90,7 +90,7 @@ AsRequired(command="version",
 
     WithNamedStep(enum="VERSION", name="version",
         OnCmd(
-            stdoutP("fs-shell\n");
+            stdoutP("presh\n");
             // ... ommitted for size
             // should be no arguments, so immediately switch to error mode.
             global_cmd = COMMAND_INDEX__ERR;

--- a/src/cmd_version.h.in
+++ b/src/cmd_version.h.in
@@ -31,7 +31,7 @@ AsRequired(command="version",
     WithNamedStep(enum="VERSION", name="version",
         OnCmd(
             // stdoutP(global_invoked_name);
-            stdoutP("fs-shell");
+            stdoutP("presh");
             stdoutP(VERSION_STR);
             for (tmp_val = 0; tmp_val < COMMAND_INDEX__LAST_NAMED_CMD; tmp_val++) {
                 // Only output included commands that are not virtual.

--- a/src/gen-cmd/cmd_version.h
+++ b/src/gen-cmd/cmd_version.h
@@ -53,7 +53,7 @@ extern const char cmd_name_version[];
         /* from cmd_version.h.in:31 */ \
             /* from cmd_version.h.in:32 */ \
             /* stdoutP(global_invoked_name);*/ \
-            stdoutP("fs-shell"); \
+            stdoutP("presh"); \
             stdoutP(VERSION_STR); \
             for (tmp_val = 0; tmp_val < COMMAND_INDEX__LAST_NAMED_CMD; tmp_val++) { \
                 /* Only output included commands that are not virtual.*/ \

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -4,7 +4,7 @@ LFLAGS = -static -static-libgcc
 
 # Debug versions are not tested, because they include a bunch
 #   of extra output.
-CMDS = fs-shell
+CMDS = presh
 
 .PHONY: all clean tests $(CMDS)
 all: clean tests
@@ -22,4 +22,4 @@ tests: $(CMDS)
 $(CMDS): $(OUTDIR)/arg_runner
 	@mkdir -p $(OUTDIR)/$@
 	@cp $(OUTDIR)/arg_runner $(OUTDIR)/$@/arg_runner
-	@TEST_TMP_DIR=$(OUTDIR)/$@ FS_SHELL=$(BINDIR)/$@ $(CURDIR)/_all.sh
+	@TEST_TMP_DIR=$(OUTDIR)/$@ PRESH=$(BINDIR)/$@ $(CURDIR)/_all.sh

--- a/tests/README.md
+++ b/tests/README.md
@@ -7,7 +7,7 @@ Set of Bash shell scripts used to test the executable.
 To run the scripts, you will need these environment variables set:
 
 * `TEST_TMP_DIR` - directory to place files that the test manipulates.
-* `FS_SHELL` - location of the compiled `fs-shell` program.
+* `PRESH` - location of the compiled `presh` program.
 * `UID1`, `UID2` - two user ids, other than the current user, to use with testing changing file ownership.
 * `GID1`, `GID2` - two group ids, other than the current user's primary group, to use with testing changing file ownership.
 
@@ -26,6 +26,6 @@ Tests should use these environment variables:
 
 * `TEST_DIR` - the directory to use for file manipulation.  The test will be run from this directory.
 * `TEST_NAME` - the name of the test.
-* `FS` - absolute path to the `fs-shell` tool.
+* `FS` - absolute path to the `presh` tool.
 * `UID0`, `GID0` - user and group ID of the currently running user.
 * `UID1`, `UID2`, `GID1`, `GID2` - additional user and group IDS for testing.

--- a/tests/_run.sh
+++ b/tests/_run.sh
@@ -2,7 +2,7 @@
 
 # Make sure the tests are setup right.
 test -d "${TEST_TMP_DIR}" || exit 99
-test -x "${FS_SHELL}" || exit 99
+test -x "${PRESH}" || exit 99
 
 RUNNER=/bin/bash
 if [ "${DEBUG}" = "1" ] ; then
@@ -26,9 +26,9 @@ here="$( dirname "${myself}" )"
 
 export UID0=$( id -u )
 export GID0=$( id -g )
-export FS="$( get_abs_filename "${FS_SHELL}" )"
+export FS="$( get_abs_filename "${PRESH}" )"
 
-fs_supports="$( "${FS}" version )"
+presh_supports="$( "${FS}" version )"
 
 FAILED=0
 for test_name in "$@" ; do
@@ -62,7 +62,7 @@ for test_name in "$@" ; do
                 # Note explicit space after the name;
                 #   this helps prevent commands like "rm" from running "rmdir"
                 #   commands, and will work because version is always last.
-                echo "${fs_supports}" | grep "${req_name} " >/dev/null 2>&1
+                echo "${presh_supports}" | grep "${req_name} " >/dev/null 2>&1
                 if [ $? ${grep_res_match} 0 ] && [ "${req_name}" != "+version" ] ; then
                     # "+version" is always last, so doesn't have the trailing space,
                     # but it must always exist, so don't skip.
@@ -113,5 +113,5 @@ for test_name in "$@" ; do
         fi
     fi
 done
-echo "${FS_SHELL} - ${FAILED} failure(s)"
+echo "${PRESH} - ${FAILED} failure(s)"
 exit ${FAILED}

--- a/tests/version-args.sh
+++ b/tests/version-args.sh
@@ -14,8 +14,8 @@ if [ ${res} -ne 1 ] ; then
 fi
 
 # Ubuntu's awk is dumb. It doesn't recognize \d or \s or \w
-# count=$( awk '/^fs-shell\s+\d+\.\d+\.\d+-\w+(\s+\+\w+)*$/{print 1}' out.txt | wc -l )
-count=$( awk '/^fs-shell [0-9]+\.[0-9]+\.[0-9]+-[a-z]+( \+[a-z-]+)*$/{print 1}' out.txt | wc -l )
+# count=$( awk '/^presh\s+\d+\.\d+\.\d+-\w+(\s+\+\w+)*$/{print 1}' out.txt | wc -l )
+count=$( awk '/^presh [0-9]+\.[0-9]+\.[0-9]+-[a-z]+( \+[a-z-]+)*$/{print 1}' out.txt | wc -l )
 res=$?
 if [ ${res} -ne 0 ] || [ ${count} -ne 1 ] ; then
     echo "Generated invalid version string (${count} / ${res}):"

--- a/tests/version-ok.sh
+++ b/tests/version-ok.sh
@@ -19,8 +19,8 @@ if [ -s err.txt ] ; then
 fi
 
 # Ubuntu's awk is dumb. It doesn't recognize \d or \s or \w
-# count=$( awk '/^fs-shell\s+\d+\.\d+\.\d+-\w+(\s+\+\w+)*$/{print 1}' out.txt | wc -l )
-count=$( awk '/^fs-shell [0-9]+\.[0-9]+\.[0-9]+-[a-z]+( \+[a-z-]+)*$/{print 1}' out.txt | wc -l )
+# count=$( awk '/^presh\s+\d+\.\d+\.\d+-\w+(\s+\+\w+)*$/{print 1}' out.txt | wc -l )
+count=$( awk '/^presh [0-9]+\.[0-9]+\.[0-9]+-[a-z]+( \+[a-z-]+)*$/{print 1}' out.txt | wc -l )
 res=$?
 if [ ${res} -ne 0 ] || [ ${count} -ne 1 ] ; then
     echo "Generated invalid version string (${count} / ${res}):"


### PR DESCRIPTION
Rebrand the tool as Precision Shell with the executable name presh.

Improved the readme to include updates in the v3 tooling.