### PR TITLE
Fix the dup-r file modifiers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,9 @@
 * [259b8e7](259b8e7a7c99a061ba98f49b991bb9ec59de4883)
     * Added a test to ensure that running `cat-fd` on a symbolic link outputs the linked file's contents correctly.
     * Added a test to ensure that running `cat-fd` on a broken symbolic link reports the correct error.
+* [a759942](a759942ae2b267023c3af7243531860e957a9f45)
+    * Added the dietlibc distribution into the `vendors` directory, due to issues seen with the source fefe.de site.
+    * Updated the `Dockerfile` for the builds to use more modern versions of the packages.
 
 
 ## v4.6.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,12 +29,11 @@ To build through Docker and capture the built executables:
 
 ```bash
 mkdir -p out
-for libname in glibc glibc-arch musl ; do
+for libname in glibc glibc-arch musl clang ; do
     docker build -t local/presh-${libname} -f build-${libname}.Dockerfile .
     container=$( docker create local/presh-${libname} )
     docker cp "${container}:/opt/code/out/presh" out/presh.${libname}
-    docker cp "${container}:/opt/code/out/presh-zipped" out/presh-zipped.${libname}
-    docker cp "${container}:/opt/code/out/presh-comp" out/presh-comp.${libname}
+    docker cp "${container}:/opt/code/out/presh-fd" out/presh-fd.${libname}
     docker cp "${container}:/opt/code/out/presh-debug" out/presh-debug.${libname}
     docker rm "${container}"
 done

--- a/src/cmd_dup.h.in
+++ b/src/cmd_dup.h.in
@@ -1,6 +1,6 @@
 /* MIT License
 
-Copyright (c) 2022 groboclown
+Copyright (c) 2022,2026 groboclown
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -56,7 +56,7 @@ WithOptional(command="dup-r",
     WithNamedStep(enum="DUP_R__SETUP", name="dup-r",
         OnCmd(
             LOG(":: preparing dup-r\n");
-            global_arg1_i = O_WRONLY | O_CREAT | O_TRUNC;
+            global_arg1_i = O_RDONLY;
             global_cmd = COMMAND_INDEX__SHARED_INT2;
             // shared int will call this index when it's done.
             global_arg3_i = COMMAND_INDEX__DUP__TGT;

--- a/src/gen-cmd/cmd_dup.h
+++ b/src/gen-cmd/cmd_dup.h
@@ -2,7 +2,7 @@
 
 /* MIT License
 
-Copyright (c) 2022 groboclown
+Copyright (c) 2022,2026 groboclown
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -135,7 +135,7 @@ extern const char cmd_name_dup_r__setup[];
         /* from cmd_dup.h.in:56 */ \
             /* from cmd_dup.h.in:57 */ \
             LOG(":: preparing dup-r\n"); \
-            global_arg1_i = O_WRONLY | O_CREAT | O_TRUNC; \
+            global_arg1_i = O_RDONLY; \
             global_cmd = COMMAND_INDEX__SHARED_INT2; \
             /* shared int will call this index when it's done.*/ \
             global_arg3_i = COMMAND_INDEX__DUP__TGT; \

--- a/tests/loop/while-error-1-loop.sh
+++ b/tests/loop/while-error-1-loop.sh
@@ -32,6 +32,10 @@ res=$?
 
 if [ ${res} -ne 0 ] ; then
     echo "Bad exit code: ${res}"
+    echo "stdout:"
+    cat out.txt
+    echo "stderr:"
+    cat err.txt
     exit 1
 fi
 

--- a/tests/read-write/dup-r.sh
+++ b/tests/read-write/dup-r.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# desc: use dup-r to pipe into into a program.
+# requires: +dup-r +exec
+
+echo "456" > contents.txt
+echo "123" >> contents.txt
+
+"${FS}" -c "dup-r 0 contents.txt && exec $( which sort )" > out.txt 2> err.txt
+res=$?
+
+if [ ${res} -ne 0 ] ; then
+    echo "Bad exit code: ${res}"
+    exit 1
+fi
+
+if [ ! -f contents.txt ] ; then
+    echo "Incorrectly removed contents.txt"
+    exit 1
+fi
+
+if [ "$( printf "123\\n456\\n" )" != "$( cat out.txt )" ] ; then
+    echo "Generated contents.txt incorrect"
+    cat contents.txt
+    exit 1
+fi
+
+if [ -s err.txt ] ; then
+    echo "Generated output to stdout or stderr"
+    echo "stdout:"
+    cat out.txt
+    echo "stderr:"
+    cat err.txt
+    exit 1
+fi
+
+# should have: out.txt and err.txt
+count="$( ls -1A | wc -l )"
+if [ ${count} != 3 ] ; then
+    echo "Generated unexpected files:"
+    ls -lA
+    exit 1
+fi


### PR DESCRIPTION
The dup-r file modifiers were incorrectly cut-and-pasted from dup-w.  This fixes them to instead allow reads.

Ref #58.