### PR TITLE
Fix the parse error result check in the exit command

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,8 @@
 * [a759942](a759942ae2b267023c3af7243531860e957a9f45)
     * Added the dietlibc distribution into the `vendors` directory, due to issues seen with the source fefe.de site.
     * Updated the `Dockerfile` for the builds to use more modern versions of the packages.
+* [e6c6f4b](e6c6f4b1e87d321e9963607634ccfd7d410256b6)
+    * Fixed a bug with the dup-r command, where it incorrectly used the same open file modifiers as the the dup-w command, which means that it ends up truncating files rather than opening them for read (#58).
 
 
 ## v4.6.0

--- a/build-tools/cmd-sizes.sh
+++ b/build-tools/cmd-sizes.sh
@@ -59,12 +59,12 @@ while [ $i -lt ${set_count} ] ; do
         cmp=""
         # no lk at the moment, as it doesn't work.
         for f in fd-tinflate fd-tinyzzz-lzma fd-tinyzzz-zstd ; do
-            if [ -f "${outfile}/presh-${f}" ] ; then
+            if [ -f "${outdir}/presh-${f}" ] ; then
                 if [ -z "${cmp}" ] ; then
                     cmp="${f}"
-                    fz1=$( wc -c <"out/presh-${f}" )
+                    fz1=$( wc -c <"${outdir}/presh-${f}" )
                 else
-                    fz2=$( wc -c <"out/presh-${f}" )
+                    fz2=$( wc -c <"${outdir}/presh-${f}" )
                     if [ ${fz2} -lt ${fz1} ] ; then
                         cmp="${f}"
                         fz1=${fz2}
@@ -75,6 +75,8 @@ while [ $i -lt ${set_count} ] ; do
 
         if [ ! -z "${cmp}" ] ; then
             echo "${fz1}|${name} (${cmp} compressed)" >> "${sizefile}"
+        else
+            ls "${outdir}/*"
         fi
     fi
     rm -rf "${outdir}"

--- a/build-tools/size-check/gather-compile-size.sh
+++ b/build-tools/size-check/gather-compile-size.sh
@@ -22,8 +22,11 @@ mkdir -p "${outdir}"
 if [ $? != 0 ] || [ ! -f "${outdir}/presh" ] ; then
     echo "${minflags}" >> "${badfile}"
 else
-    filesize=$( wc -c <"${outdir}/presh" )
+    filesize1=$( wc -c <"${outdir}/presh" )
+    filesize2=$( wc -c <"${outdir}/presh-fd" )
     rm -r "${outdir}"
-    echo "${filesize}|${minflags}|${COMMAND_FLAGS}" >> "${sizefile}"
-    echo "${filesize} < ${minflags}"
+    echo "${filesize1}|${minflags}|std|${COMMAND_FLAGS}" >> "${sizefile}"
+    echo "${filesize2}|${minflags}|compressed|${COMMAND_FLAGS}" >> "${sizefile}"
+    echo "${filesize1} < ${minflags} (std)"
+    echo "${filesize2} < ${minflags} (compressed)"
 fi

--- a/src/cmd_exit.h.in
+++ b/src/cmd_exit.h.in
@@ -1,7 +1,7 @@
 /*
 MIT License
 
-Copyright (c) 2022 groboclown
+Copyright (c) 2022,2026 groboclown
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -38,7 +38,7 @@ WithNamedStep(enum="EXIT", name="exit",
     OnArg(
         // An argument is required.
         global_err = helper_arg_to_uint(global_arg, 10, 0xff);
-        if (global_arg1_i < 0) {
+        if (global_err < 0) {
             LOG("::  - Bad exit code, or out of range\n");
             global_cmd = COMMAND_INDEX__ERR;
             global_err = 1;

--- a/src/gen-cmd/cmd_exit.h
+++ b/src/gen-cmd/cmd_exit.h
@@ -3,7 +3,7 @@
 /*
 MIT License
 
-Copyright (c) 2022 groboclown
+Copyright (c) 2022,2026 groboclown
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -61,7 +61,7 @@ extern const char cmd_name_exit[];
             /* from cmd_exit.h.in:38 */ \
         /* An argument is required.*/ \
         global_err = helper_arg_to_uint(global_arg, 10, 0xff); \
-        if (global_arg1_i < 0) { \
+        if (global_err < 0) { \
             LOG("::  - Bad exit code, or out of range\n"); \
             global_cmd = COMMAND_INDEX__ERR; \
             global_err = 1; \


### PR DESCRIPTION
Fix wrong variable for exit argument checking (#59)

Also, includes fixes to the command size discovery scripts.