### PR TITLE
Fix the wait-pid command.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,8 @@
     * Updated the `Dockerfile` for the builds to use more modern versions of the packages.
 * [e6c6f4b](e6c6f4b1e87d321e9963607634ccfd7d410256b6)
     * Fixed a bug with the dup-r command, where it incorrectly used the same open file modifiers as the the dup-w command, which means that it ends up truncating files rather than opening them for read (#58).
+* [3cf56f6](3cf56f6d93b7609a720c51b7a607f2fb3461eacc)
+    * Fixed a bug with the exit command where it incorrectly checks the result of parsing the argument, leading to a potential wrong exit code (#59).
 
 
 ## v4.6.0

--- a/src/cmd_wait_pid.h.in
+++ b/src/cmd_wait_pid.h.in
@@ -1,6 +1,6 @@
 /* MIT License
 
-Copyright (c) 2022 groboclown
+Copyright (c) 2022,2026 groboclown
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -60,6 +60,7 @@ WithNamedStep(enum="WAIT_PID", name="wait-pid",
                 LOG("::  - Bad number, or out of range\n");
                 global_cmd = COMMAND_INDEX__ERR;
                 global_err = 1;
+                goto wait_pid_end;
             }
         }
         global_arg2_i = waitpid(global_arg1_i, &global_arg3_i, 0); 
@@ -73,6 +74,7 @@ WithNamedStep(enum="WAIT_PID", name="wait-pid",
             LOGLN(&global_arg[1]);
             setenv(&global_arg[1], global_itoa_ptr, 1);
         }
+    wait_pid_end:
     )
 )
 

--- a/src/gen-cmd/cmd_wait_pid.h
+++ b/src/gen-cmd/cmd_wait_pid.h
@@ -2,7 +2,7 @@
 
 /* MIT License
 
-Copyright (c) 2022 groboclown
+Copyright (c) 2022,2026 groboclown
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -85,6 +85,7 @@ extern const char cmd_name_wait_pid[];
                 LOG("::  - Bad number, or out of range\n"); \
                 global_cmd = COMMAND_INDEX__ERR; \
                 global_err = 1; \
+                goto wait_pid_end; \
             } \
         } \
         global_arg2_i = waitpid(global_arg1_i, &global_arg3_i, 0); \
@@ -98,6 +99,7 @@ extern const char cmd_name_wait_pid[];
             LOGLN(&global_arg[1]); \
             setenv(&global_arg[1], global_itoa_ptr, 1); \
         } \
+    wait_pid_end: \
         break;
 #define REQUIRES_ADDL_ARG__WAIT_PID
 

--- a/tests/read-write/dup-r-w-exec.sh
+++ b/tests/read-write/dup-r-w-exec.sh
@@ -3,9 +3,6 @@
 # desc: pipe output using dup-w and dup-r into a program
 # requires: +dup-w +dup-r +exec +echo
 
-echo "?? SKIPPED BECAUSE IT REQUIRES DEBUGGING"
-exit 0
-
 echo "dup-w 1 contents.txt" > script.txt
 echo "echo foo bar baz" >> script.txt
 echo "dup-w 1 sorted.txt" >> script.txt
@@ -25,13 +22,13 @@ if [ ! -f contents.txt ] || [ ! -f sorted.txt ] ; then
     exit 1
 fi
 
-if [ "$( printf "foo\\nbar\\baz\\n" )" != "$( cat contents.txt )" ] ; then
+if [ "$( printf "foo\\nbar\\nbaz\\n" )" != "$( cat contents.txt )" ] ; then
     echo "Generated contents.txt incorrect"
     cat contents.txt
     exit 1
 fi
 
-if [ "$( printf "bar\\nbaz\\foo\\n" )" != "$( cat sorted.txt )" ] ; then
+if [ "$( printf "bar\\nbaz\\nfoo\\n" )" != "$( cat sorted.txt )" ] ; then
     echo "Generated sorted.txt incorrect"
     cat sorted.txt
     exit 1
@@ -48,7 +45,7 @@ fi
 
 # should have: out.txt and err.txt
 count="$( ls -1A | wc -l )"
-if [ ${count} != 2 ] ; then
+if [ ${count} != 5 ] ; then
     echo "Generated unexpected files:"
     ls -lA
     exit 1


### PR DESCRIPTION
The wait-pid command did not properly stop on error conditions, but instead kept running, using a -1 for the pid to wait on.  This meant that, on error conditions (such as bad argument parsing), the wait-pid command would reap child processes, rather than letting other wait-pid requests perform that action.

Ref #57 