### PR TITLE
Fix argument parse buffer overflow and status check

### DIFF
--- a/src/cmd_exec.h.in
+++ b/src/cmd_exec.h.in
@@ -1,7 +1,7 @@
 /*
 MIT License
 
-Copyright (c) 2022 groboclown
+Copyright (c) 2022,2026 groboclown
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -56,14 +56,17 @@ WithNamedStep(enum="EXEC", name="exec",
     OnArg(
         // Split the arguments.
         SHARED_SPLIT__PARSE_ARG
-        EXEC_DEBUG_REPORT
-        // This launches a new executable and terminates this one immediately.
-        execvp(shared_split_argv[0], (char * const*) shared_split_argv);
+        if (global_err == 0) {
+            EXEC_DEBUG_REPORT
+            // This launches a new executable and terminates this one immediately.
+            execvp(shared_split_argv[0], (char * const*) shared_split_argv);
+            
+            // If the code is still running at this point, then there was an error.
+            // Rather than returning, allow the next command argument to run.
+            // Additionally, this will allow normal error reporting to report the problem.
+            global_err = 1;
+        }
 
-        // If the code is still running at this point, then there was an error.
-        // Rather than returning, allow the next command argument to run.
-        // Additionally, this will allow normal error reporting to report the problem.
-        global_err = 1;
         break;
     )
 )

--- a/src/cmd_shared_sub_args.h.in
+++ b/src/cmd_shared_sub_args.h.in
@@ -1,6 +1,6 @@
 /* MIT License
 
-Copyright (c) 2022 groboclown
+Copyright (c) 2022,2026 groboclown
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -52,7 +52,7 @@ AsOptional(command="shared-sub-args", ifdef="USES_SHARED_SPLIT_ARG",
         shared_split_arg = args_advance_token(shared_split_arg_state); \
         if (shared_split_arg->state == ARG_STATE_END) { \
             break; \
-        } else if (shared_split_arg->state == ARG_STATE_ERR) { \
+        } else if (global_arg3_i >= MAX_SUB_ARG_COUNT || shared_split_arg->state == ARG_STATE_ERR) { \
             global_err = 1; \
             break; \
         } else { \

--- a/src/cmd_signal.h.in
+++ b/src/cmd_signal.h.in
@@ -32,6 +32,10 @@ void signal_handler(int);
 
 char signal_env_name[PARSED_ARG_SIZE] = "";
 
+// As a signal handler, this has shaky, at best, logic.
+// POSIX standard does not claim that setenv or write (called by LOG)
+// are async-signal-safe.  shared_itoa should be fine as long as the
+// buffer is read-only.
 #define SIGNAL_ENV_CAPTURE \
     char signal_itoa[(3 * sizeof(long int)) + 8]; \
     if (signal_env_name[0] != '\0') { \

--- a/src/cmd_spawn.h.in
+++ b/src/cmd_spawn.h.in
@@ -67,36 +67,37 @@ WithVirtualStep(enum="SPAWN__CMD",
         // Split the arguments first.  This is inefficient for the
         // parent, but cleans up debug output.
         SHARED_SPLIT__PARSE_ARG
-        SPAWN_DEBUG_REPORT
+        if (global_err == 0) {
+            SPAWN_DEBUG_REPORT
 
+            // Fork the process.  This will have the potential to
+            // cause very weird behavior if no argument is given.
+            global_arg3_i = fork();
+            if (global_arg3_i == -1) {
+                LOG(":: failed to fork process\n");
+                global_err = 1;
+                global_cmd = COMMAND_INDEX__ERR;
+            } else if (global_arg3_i == 0) {
 
-        // Fork the process.  This will have the potential to
-        // cause very weird behavior if no argument is given.
-        global_arg3_i = fork();
-        if (global_arg3_i == -1) {
-            LOG(":: failed to fork process\n");
-            global_err = 1;
-            global_cmd = COMMAND_INDEX__ERR;
-        } else if (global_arg3_i == 0) {
+                // Execute in the same OnArg block as the fork.  This inhibits much
+                // of the print statements that would possibly clutter the output as
+                // both processes try to write to stdout in debug mode.  This also
+                // inhibits weird issues if there wasn't an executable argument.
 
-            // Execute in the same OnArg block as the fork.  This inhibits much
-            // of the print statements that would possibly clutter the output as
-            // both processes try to write to stdout in debug mode.  This also
-            // inhibits weird issues if there wasn't an executable argument.
+                // This launches a new executable and terminates this one immediately.
+                execvp(shared_split_argv[0], (char * const*) shared_split_argv);
 
-            // This launches a new executable and terminates this one immediately.
-            execvp(shared_split_argv[0], (char * const*) shared_split_argv);
+                // Exit rather than return.  A failed exec then performing
+                //   a return can cause a sub-command context to start running,
+                //   which is Very Bad.
+                _exit(1);
 
-            // Exit rather than return.  A failed exec then performing
-            //   a return can cause a sub-command context to start running,
-            //   which is Very Bad.
-            _exit(1);
-
-        } else {
-            // Else this is the parent process.
-            // Just slurp up this argument.
-            // Then, if the env is next, post the pid to that.
-            global_cmd = COMMAND_INDEX__SPAWN__PID;
+            } else {
+                // Else this is the parent process.
+                // Just slurp up this argument.
+                // Then, if the env is next, post the pid to that.
+                global_cmd = COMMAND_INDEX__SPAWN__PID;
+            }
         }
     )
 )

--- a/src/cmd_su_exec.h.in
+++ b/src/cmd_su_exec.h.in
@@ -1,7 +1,7 @@
 /*
 MIT License
 
-Copyright (c) 2022 groboclown
+Copyright (c) 2022,2026 groboclown
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -30,6 +30,7 @@ AsOptional(command="su-exec",
 #include <stdlib.h>
 #include <stdio.h>
 #include <unistd.h>
+#include <grp.h>
 #include "args.h"
 #include "output.h"
 #include "globals.h"
@@ -81,24 +82,29 @@ WithVirtualStep(enum="SU_EXEC__RUN",
     OnArg(
         // Split the arguments.
         SHARED_SPLIT__PARSE_ARG
-        SU_EXEC_DEBUG_REPORT
+        if (global_err == 0) {
+            SU_EXEC_DEBUG_REPORT
 
-        // Delay switching UID and GID until the last possible moment.
-        // Note that gid is done first.
-        global_arg1_i = setgid(global_arg1_i);
-        if (global_arg1_i >= 0) {
-            global_arg1_i = setuid(global_arg2_i);
-            if (global_arg1_i >= 0) {
-                // This launches a new executable and terminates this one immediately.
-                execvp(shared_split_argv[0], (char * const*) shared_split_argv);
+            // Delay switching UID and GID until the last possible moment.
+            tmp_val = setgroups(0, NULL);
+            if (tmp_val >= 0) {
+                // Note that gid is done first.
+                tmp_val = setgid(global_arg1_i);
+                if (tmp_val >= 0) {
+                    tmp_val = setuid(global_arg2_i);
+                    if (tmp_val >= 0) {
+                        // This launches a new executable and terminates this one immediately.
+                        execvp(shared_split_argv[0], (char * const*) shared_split_argv);
+                    }
+                }
             }
-        }
 
-        // Unlike the normal exec, this must exit
-        // immediately due to the setuid/setgid.  We don't
-        // want unexpected commands running with unexpected permissions.
-        stderrP("Failed to su-exec ");
-        stderrPLn(shared_split_argv[0]);
+            // Unlike the normal exec, this must exit
+            // immediately due to the setuid/setgid.  We don't
+            // want unexpected commands running with unexpected permissions.
+            stderrP("Failed to su-exec ");
+            stderrPLn(shared_split_argv[0]);
+        }
         _exit(1);
     )
 )

--- a/src/cmd_su_spawn.h.in
+++ b/src/cmd_su_spawn.h.in
@@ -28,6 +28,7 @@ AsOptional(command="su-spawn",
 
 #include <stdlib.h>
 #include <unistd.h>
+#include <grp.h>
 #include "args.h"
 #include "output.h"
 #include "globals.h"
@@ -82,46 +83,50 @@ WithVirtualStep(enum="SU_SPAWN__CMD",
         // Split the arguments first.  This is inefficient for the
         // parent, but cleans up debug output.
         SHARED_SPLIT__PARSE_ARG
-        SU_SPAWN_DEBUG_REPORT
+        if (global_err == 0) {
+            SU_SPAWN_DEBUG_REPORT
 
+            // Fork the process.  This will have the potential to
+            // cause very weird behavior if no argument is given.
+            global_arg3_i = fork();
+            if (global_arg3_i == -1) {
+                LOG(":: failed to fork process\n");
+                global_err = 1;
+                global_cmd = COMMAND_INDEX__ERR;
+            } else if (global_arg3_i == 0) {
 
-        // Fork the process.  This will have the potential to
-        // cause very weird behavior if no argument is given.
-        global_arg3_i = fork();
-        if (global_arg3_i == -1) {
-            LOG(":: failed to fork process\n");
-            global_err = 1;
-            global_cmd = COMMAND_INDEX__ERR;
-        } else if (global_arg3_i == 0) {
+                // Execute in the same OnArg block as the fork.  This inhibits much
+                // of the print statements that would possibly clutter the output as
+                // both processes try to write to stdout in debug mode.  This also
+                // inhibits weird issues if there wasn't an executable argument.
 
-            // Execute in the same OnArg block as the fork.  This inhibits much
-            // of the print statements that would possibly clutter the output as
-            // both processes try to write to stdout in debug mode.  This also
-            // inhibits weird issues if there wasn't an executable argument.
-
-            // Delay switching UID and GID until the last possible moment.
-            // Note that gid is done first.
-            global_arg1_i = setgid(global_arg1_i);
-            if (global_arg1_i >= 0) {
-                global_arg1_i = setuid(global_arg2_i);
-                if (global_arg1_i >= 0) {
-                    // This launches a new executable and terminates this one immediately.
-                    execvp(shared_split_argv[0], (char * const*) shared_split_argv);
+                // Delay switching UID and GID until the last possible moment.
+                // Note that gid is done first.
+                tmp_val = setgroups(0, NULL);
+                if (tmp_val >= 0) {
+                    tmp_val = setgid(global_arg1_i);
+                    if (tmp_val >= 0) {
+                        tmp_val = setuid(global_arg2_i);
+                        if (tmp_val >= 0) {
+                            // This launches a new executable and terminates this one immediately.
+                            execvp(shared_split_argv[0], (char * const*) shared_split_argv);
+                        }
+                    }
                 }
+
+
+                // Unlike the normal exec, this must exit
+                // immediately due to the setuid/setgid.  We don't
+                // want unexpected commands running in an unexpected state.
+                stderrP("Failed to su-spawn ");
+                stderrPLn(shared_split_argv[0]);
+                _exit(1);
+            } else {
+                // Else this is the parent process.
+                // Just slurp up this argument.
+                // Then, if the env is next, post the pid to that.
+                global_cmd = COMMAND_INDEX__SU_SPAWN__PID;
             }
-
-
-            // Unlike the normal exec, this must exit
-            // immediately due to the setuid/setgid.  We don't
-            // want unexpected commands running in an unexpected state.
-            stderrP("Failed to su-spawn ");
-            stderrPLn(shared_split_argv[0]);
-            _exit(1);
-        } else {
-            // Else this is the parent process.
-            // Just slurp up this argument.
-            // Then, if the env is next, post the pid to that.
-            global_cmd = COMMAND_INDEX__SU_SPAWN__PID;
         }
     )
 )

--- a/src/gen-cmd/cmd_exec.h
+++ b/src/gen-cmd/cmd_exec.h
@@ -3,7 +3,7 @@
 /*
 MIT License
 
-Copyright (c) 2022 groboclown
+Copyright (c) 2022,2026 groboclown
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -80,13 +80,15 @@ extern const char cmd_name_exec[];
             /* from cmd_exec.h.in:56 */ \
         /* Split the arguments.*/ \
         SHARED_SPLIT__PARSE_ARG \
-        EXEC_DEBUG_REPORT \
-        /* This launches a new executable and terminates this one immediately.*/ \
-        execvp(shared_split_argv[0], (char * const*) shared_split_argv); \
-        /* If the code is still running at this point, then there was an error.*/ \
-        /* Rather than returning, allow the next command argument to run.*/ \
-        /* Additionally, this will allow normal error reporting to report the problem.*/ \
-        global_err = 1; \
+        if (global_err == 0) { \
+            EXEC_DEBUG_REPORT \
+            /* This launches a new executable and terminates this one immediately.*/ \
+            execvp(shared_split_argv[0], (char * const*) shared_split_argv); \
+            /* If the code is still running at this point, then there was an error.*/ \
+            /* Rather than returning, allow the next command argument to run.*/ \
+            /* Additionally, this will allow normal error reporting to report the problem.*/ \
+            global_err = 1; \
+        } \
         break; \
         break;
 #define REQUIRES_ADDL_ARG__EXEC

--- a/src/gen-cmd/cmd_shared_sub_args.h
+++ b/src/gen-cmd/cmd_shared_sub_args.h
@@ -2,7 +2,7 @@
 
 /* MIT License
 
-Copyright (c) 2022 groboclown
+Copyright (c) 2022,2026 groboclown
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -61,7 +61,7 @@ SOFTWARE.
         shared_split_arg = args_advance_token(shared_split_arg_state); \
         if (shared_split_arg->state == ARG_STATE_END) { \
             break; \
-        } else if (shared_split_arg->state == ARG_STATE_ERR) { \
+        } else if (global_arg3_i >= MAX_SUB_ARG_COUNT || shared_split_arg->state == ARG_STATE_ERR) { \
             global_err = 1; \
             break; \
         } else { \

--- a/src/gen-cmd/cmd_signal.h
+++ b/src/gen-cmd/cmd_signal.h
@@ -41,6 +41,10 @@ void signal_handler(int);
 
 char signal_env_name[PARSED_ARG_SIZE] = "";
 
+// As a signal handler, this has shaky, at best, logic.
+// POSIX standard does not claim that setenv or write (called by LOG)
+// are async-signal-safe.  shared_itoa should be fine as long as the
+// buffer is read-only.
 #define SIGNAL_ENV_CAPTURE \
     char signal_itoa[(3 * sizeof(long int)) + 8]; \
     if (signal_env_name[0] != '\0') { \
@@ -70,36 +74,36 @@ char signal_env_name[PARSED_ARG_SIZE] = "";
 #endif
 
 
-/* from cmd_signal.h.in:63 */
+/* from cmd_signal.h.in:67 */
 extern const char cmd_name_signal[];
 #define ENUM_LIST__SIGNAL \
-            /* from cmd_signal.h.in:63 */ \
+            /* from cmd_signal.h.in:67 */ \
             COMMAND_INDEX__SIGNAL,
 #define VIRTUAL_ENUM_LIST__SIGNAL
 #define GLOBAL_VARDEF__SIGNAL \
-            /* from cmd_signal.h.in:63 */ \
+            /* from cmd_signal.h.in:67 */ \
             const char cmd_name_signal[] = "signal"; \
-            /* from cmd_signal.h.in:64 */ \
+            /* from cmd_signal.h.in:68 */ \
 void signal_handler(int signal) { \
     SIGNAL_ENV_CAPTURE; \
     LOG(":: handled signal\n"); \
 }
 #define INITIALIZE__SIGNAL \
-            /* from cmd_signal.h.in:63 */ \
+            /* from cmd_signal.h.in:67 */ \
             command_list_names[COMMAND_INDEX__SIGNAL] = cmd_name_signal; \
-            /* from cmd_signal.h.in:72 */ \
+            /* from cmd_signal.h.in:76 */ \
             sigset_t global_signal_set;
 #define STARTUP_CASE__SIGNAL \
     case COMMAND_INDEX__SIGNAL: \
-        /* from cmd_signal.h.in:63 */ \
-            /* from cmd_signal.h.in:76 */ \
+        /* from cmd_signal.h.in:67 */ \
+            /* from cmd_signal.h.in:80 */ \
             LOG(":: Initializing for signal handling\n"); \
             sigemptyset(&global_signal_set); \
         break;
 #define RUN_CASE__SIGNAL \
     case COMMAND_INDEX__SIGNAL: \
-        /* from cmd_signal.h.in:63 */ \
-            /* from cmd_signal.h.in:81 */ \
+        /* from cmd_signal.h.in:67 */ \
+            /* from cmd_signal.h.in:85 */ \
             /* The "wait" string indicates the end of the signals.*/ \
             if (strequal("wait", global_arg)) { \
                 LOG(":: start signal wait\n"); \

--- a/src/gen-cmd/cmd_spawn.h
+++ b/src/gen-cmd/cmd_spawn.h
@@ -73,7 +73,7 @@ extern const char cmd_name_spawn[];
 #define VIRTUAL_ENUM_LIST__SPAWN \
             /* from cmd_spawn.h.in:63 */ \
             COMMAND_INDEX__SPAWN__CMD, \
-            /* from cmd_spawn.h.in:104 */ \
+            /* from cmd_spawn.h.in:105 */ \
             COMMAND_INDEX__SPAWN__PID,
 #define GLOBAL_VARDEF__SPAWN \
             /* from cmd_spawn.h.in:53 */ \
@@ -96,35 +96,37 @@ extern const char cmd_name_spawn[];
         /* Split the arguments first.  This is inefficient for the*/ \
         /* parent, but cleans up debug output.*/ \
         SHARED_SPLIT__PARSE_ARG \
-        SPAWN_DEBUG_REPORT \
-        /* Fork the process.  This will have the potential to*/ \
-        /* cause very weird behavior if no argument is given.*/ \
-        global_arg3_i = fork(); \
-        if (global_arg3_i == -1) { \
-            LOG(":: failed to fork process\n"); \
-            global_err = 1; \
-            global_cmd = COMMAND_INDEX__ERR; \
-        } else if (global_arg3_i == 0) { \
-            /* Execute in the same OnArg block as the fork.  This inhibits much*/ \
-            /* of the print statements that would possibly clutter the output as*/ \
-            /* both processes try to write to stdout in debug mode.  This also*/ \
-            /* inhibits weird issues if there wasn't an executable argument.*/ \
-            /* This launches a new executable and terminates this one immediately.*/ \
-            execvp(shared_split_argv[0], (char * const*) shared_split_argv); \
-            /* Exit rather than return.  A failed exec then performing*/ \
-            /*   a return can cause a sub-command context to start running,*/ \
-            /*   which is Very Bad.*/ \
-            _exit(1); \
-        } else { \
-            /* Else this is the parent process.*/ \
-            /* Just slurp up this argument.*/ \
-            /* Then, if the env is next, post the pid to that.*/ \
-            global_cmd = COMMAND_INDEX__SPAWN__PID; \
+        if (global_err == 0) { \
+            SPAWN_DEBUG_REPORT \
+            /* Fork the process.  This will have the potential to*/ \
+            /* cause very weird behavior if no argument is given.*/ \
+            global_arg3_i = fork(); \
+            if (global_arg3_i == -1) { \
+                LOG(":: failed to fork process\n"); \
+                global_err = 1; \
+                global_cmd = COMMAND_INDEX__ERR; \
+            } else if (global_arg3_i == 0) { \
+                /* Execute in the same OnArg block as the fork.  This inhibits much*/ \
+                /* of the print statements that would possibly clutter the output as*/ \
+                /* both processes try to write to stdout in debug mode.  This also*/ \
+                /* inhibits weird issues if there wasn't an executable argument.*/ \
+                /* This launches a new executable and terminates this one immediately.*/ \
+                execvp(shared_split_argv[0], (char * const*) shared_split_argv); \
+                /* Exit rather than return.  A failed exec then performing*/ \
+                /*   a return can cause a sub-command context to start running,*/ \
+                /*   which is Very Bad.*/ \
+                _exit(1); \
+            } else { \
+                /* Else this is the parent process.*/ \
+                /* Just slurp up this argument.*/ \
+                /* Then, if the env is next, post the pid to that.*/ \
+                global_cmd = COMMAND_INDEX__SPAWN__PID; \
+            } \
         } \
         break; \
     case COMMAND_INDEX__SPAWN__PID: \
-        /* from cmd_spawn.h.in:104 */ \
-            /* from cmd_spawn.h.in:105 */ \
+        /* from cmd_spawn.h.in:105 */ \
+            /* from cmd_spawn.h.in:106 */ \
         /* Put the PID into the environment variable global_arg.*/ \
         /* This argument can only be run from the parent due to the logic above.*/ \
         global_itoa_ptr = shared_itoa(global_arg3_i, global_itoa); \

--- a/src/gen-cmd/cmd_su_exec.h
+++ b/src/gen-cmd/cmd_su_exec.h
@@ -3,7 +3,7 @@
 /*
 MIT License
 
-Copyright (c) 2022 groboclown
+Copyright (c) 2022,2026 groboclown
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -39,6 +39,7 @@ SOFTWARE.
 #include <stdlib.h>
 #include <stdio.h>
 #include <unistd.h>
+#include <grp.h>
 #include "args.h"
 #include "output.h"
 #include "globals.h"
@@ -63,32 +64,32 @@ SOFTWARE.
 
 
 
-/* from cmd_su_exec.h.in:55 */
+/* from cmd_su_exec.h.in:56 */
 extern const char cmd_name_su_exec[];
 #define ENUM_LIST__SU_EXEC \
-            /* from cmd_su_exec.h.in:55 */ \
+            /* from cmd_su_exec.h.in:56 */ \
             COMMAND_INDEX__SU_EXEC,
 #define VIRTUAL_ENUM_LIST__SU_EXEC \
-            /* from cmd_su_exec.h.in:79 */ \
+            /* from cmd_su_exec.h.in:80 */ \
             COMMAND_INDEX__SU_EXEC__RUN,
 #define GLOBAL_VARDEF__SU_EXEC \
-            /* from cmd_su_exec.h.in:55 */ \
+            /* from cmd_su_exec.h.in:56 */ \
             const char cmd_name_su_exec[] = "su-exec";
 #define INITIALIZE__SU_EXEC \
-            /* from cmd_su_exec.h.in:55 */ \
+            /* from cmd_su_exec.h.in:56 */ \
             command_list_names[COMMAND_INDEX__SU_EXEC] = cmd_name_su_exec;
 #define STARTUP_CASE__SU_EXEC \
     case COMMAND_INDEX__SU_EXEC: \
-        /* from cmd_su_exec.h.in:55 */ \
-            /* from cmd_su_exec.h.in:58 */ \
+        /* from cmd_su_exec.h.in:56 */ \
+            /* from cmd_su_exec.h.in:59 */ \
         /* arg2: uid*/ \
         global_cmd = COMMAND_INDEX__SHARED_INT2; \
         global_arg3_i = COMMAND_INDEX__SU_EXEC; \
         break;
 #define RUN_CASE__SU_EXEC \
     case COMMAND_INDEX__SU_EXEC: \
-        /* from cmd_su_exec.h.in:55 */ \
-            /* from cmd_su_exec.h.in:64 */ \
+        /* from cmd_su_exec.h.in:56 */ \
+            /* from cmd_su_exec.h.in:65 */ \
         /* arg1: gid*/ \
         LOG(":: storing gid "); \
         LOGLN(global_arg); \
@@ -102,26 +103,31 @@ extern const char cmd_name_su_exec[];
         global_cmd = COMMAND_INDEX__SU_EXEC__RUN; \
         break; \
     case COMMAND_INDEX__SU_EXEC__RUN: \
-        /* from cmd_su_exec.h.in:79 */ \
-            /* from cmd_su_exec.h.in:81 */ \
+        /* from cmd_su_exec.h.in:80 */ \
+            /* from cmd_su_exec.h.in:82 */ \
         /* Split the arguments.*/ \
         SHARED_SPLIT__PARSE_ARG \
-        SU_EXEC_DEBUG_REPORT \
-        /* Delay switching UID and GID until the last possible moment.*/ \
-        /* Note that gid is done first.*/ \
-        global_arg1_i = setgid(global_arg1_i); \
-        if (global_arg1_i >= 0) { \
-            global_arg1_i = setuid(global_arg2_i); \
-            if (global_arg1_i >= 0) { \
-                /* This launches a new executable and terminates this one immediately.*/ \
-                execvp(shared_split_argv[0], (char * const*) shared_split_argv); \
+        if (global_err == 0) { \
+            SU_EXEC_DEBUG_REPORT \
+            /* Delay switching UID and GID until the last possible moment.*/ \
+            tmp_val = setgroups(0, NULL); \
+            if (tmp_val >= 0) { \
+                /* Note that gid is done first.*/ \
+                tmp_val = setgid(global_arg1_i); \
+                if (tmp_val >= 0) { \
+                    tmp_val = setuid(global_arg2_i); \
+                    if (tmp_val >= 0) { \
+                        /* This launches a new executable and terminates this one immediately.*/ \
+                        execvp(shared_split_argv[0], (char * const*) shared_split_argv); \
+                    } \
+                } \
             } \
+            /* Unlike the normal exec, this must exit*/ \
+            /* immediately due to the setuid/setgid.  We don't*/ \
+            /* want unexpected commands running with unexpected permissions.*/ \
+            stderrP("Failed to su-exec "); \
+            stderrPLn(shared_split_argv[0]); \
         } \
-        /* Unlike the normal exec, this must exit*/ \
-        /* immediately due to the setuid/setgid.  We don't*/ \
-        /* want unexpected commands running with unexpected permissions.*/ \
-        stderrP("Failed to su-exec "); \
-        stderrPLn(shared_split_argv[0]); \
         _exit(1); \
         break;
 #define REQUIRES_ADDL_ARG__SU_EXEC \

--- a/src/gen-cmd/cmd_su_spawn.h
+++ b/src/gen-cmd/cmd_su_spawn.h
@@ -37,6 +37,7 @@ SOFTWARE.
 
 #include <stdlib.h>
 #include <unistd.h>
+#include <grp.h>
 #include "args.h"
 #include "output.h"
 #include "globals.h"
@@ -66,34 +67,34 @@ SOFTWARE.
 
     // If this doesn't have another argument, bad things will happen.
 
-/* from cmd_su_spawn.h.in:53 */
+/* from cmd_su_spawn.h.in:54 */
 extern const char cmd_name_su_spawn[];
 #define ENUM_LIST__SU_SPAWN \
-            /* from cmd_su_spawn.h.in:53 */ \
+            /* from cmd_su_spawn.h.in:54 */ \
             COMMAND_INDEX__SU_SPAWN,
 #define VIRTUAL_ENUM_LIST__SU_SPAWN \
-            /* from cmd_su_spawn.h.in:78 */ \
+            /* from cmd_su_spawn.h.in:79 */ \
             COMMAND_INDEX__SU_SPAWN__CMD, \
-            /* from cmd_su_spawn.h.in:130 */ \
+            /* from cmd_su_spawn.h.in:135 */ \
             COMMAND_INDEX__SU_SPAWN__PID,
 #define GLOBAL_VARDEF__SU_SPAWN \
-            /* from cmd_su_spawn.h.in:53 */ \
+            /* from cmd_su_spawn.h.in:54 */ \
             const char cmd_name_su_spawn[] = "su-spawn";
 #define INITIALIZE__SU_SPAWN \
-            /* from cmd_su_spawn.h.in:53 */ \
+            /* from cmd_su_spawn.h.in:54 */ \
             command_list_names[COMMAND_INDEX__SU_SPAWN] = cmd_name_su_spawn;
 #define STARTUP_CASE__SU_SPAWN \
     case COMMAND_INDEX__SU_SPAWN: \
-        /* from cmd_su_spawn.h.in:53 */ \
-            /* from cmd_su_spawn.h.in:57 */ \
+        /* from cmd_su_spawn.h.in:54 */ \
+            /* from cmd_su_spawn.h.in:58 */ \
         /* arg2: uid*/ \
         global_cmd = COMMAND_INDEX__SHARED_INT2; \
         global_arg3_i = COMMAND_INDEX__SU_SPAWN; \
         break;
 #define RUN_CASE__SU_SPAWN \
     case COMMAND_INDEX__SU_SPAWN: \
-        /* from cmd_su_spawn.h.in:53 */ \
-            /* from cmd_su_spawn.h.in:63 */ \
+        /* from cmd_su_spawn.h.in:54 */ \
+            /* from cmd_su_spawn.h.in:64 */ \
         /* arg1: gid*/ \
         LOG(":: storing gid "); \
         LOGLN(global_arg); \
@@ -107,51 +108,56 @@ extern const char cmd_name_su_spawn[];
         global_cmd = COMMAND_INDEX__SU_SPAWN__CMD; \
         break; \
     case COMMAND_INDEX__SU_SPAWN__CMD: \
-        /* from cmd_su_spawn.h.in:78 */ \
-            /* from cmd_su_spawn.h.in:79 */ \
+        /* from cmd_su_spawn.h.in:79 */ \
+            /* from cmd_su_spawn.h.in:80 */ \
         /* global_arg3_i == pid*/ \
         /* Split the arguments first.  This is inefficient for the*/ \
         /* parent, but cleans up debug output.*/ \
         SHARED_SPLIT__PARSE_ARG \
-        SU_SPAWN_DEBUG_REPORT \
-        /* Fork the process.  This will have the potential to*/ \
-        /* cause very weird behavior if no argument is given.*/ \
-        global_arg3_i = fork(); \
-        if (global_arg3_i == -1) { \
-            LOG(":: failed to fork process\n"); \
-            global_err = 1; \
-            global_cmd = COMMAND_INDEX__ERR; \
-        } else if (global_arg3_i == 0) { \
-            /* Execute in the same OnArg block as the fork.  This inhibits much*/ \
-            /* of the print statements that would possibly clutter the output as*/ \
-            /* both processes try to write to stdout in debug mode.  This also*/ \
-            /* inhibits weird issues if there wasn't an executable argument.*/ \
-            /* Delay switching UID and GID until the last possible moment.*/ \
-            /* Note that gid is done first.*/ \
-            global_arg1_i = setgid(global_arg1_i); \
-            if (global_arg1_i >= 0) { \
-                global_arg1_i = setuid(global_arg2_i); \
-                if (global_arg1_i >= 0) { \
-                    /* This launches a new executable and terminates this one immediately.*/ \
-                    execvp(shared_split_argv[0], (char * const*) shared_split_argv); \
+        if (global_err == 0) { \
+            SU_SPAWN_DEBUG_REPORT \
+            /* Fork the process.  This will have the potential to*/ \
+            /* cause very weird behavior if no argument is given.*/ \
+            global_arg3_i = fork(); \
+            if (global_arg3_i == -1) { \
+                LOG(":: failed to fork process\n"); \
+                global_err = 1; \
+                global_cmd = COMMAND_INDEX__ERR; \
+            } else if (global_arg3_i == 0) { \
+                /* Execute in the same OnArg block as the fork.  This inhibits much*/ \
+                /* of the print statements that would possibly clutter the output as*/ \
+                /* both processes try to write to stdout in debug mode.  This also*/ \
+                /* inhibits weird issues if there wasn't an executable argument.*/ \
+                /* Delay switching UID and GID until the last possible moment.*/ \
+                /* Note that gid is done first.*/ \
+                tmp_val = setgroups(0, NULL); \
+                if (tmp_val >= 0) { \
+                    tmp_val = setgid(global_arg1_i); \
+                    if (tmp_val >= 0) { \
+                        tmp_val = setuid(global_arg2_i); \
+                        if (tmp_val >= 0) { \
+                            /* This launches a new executable and terminates this one immediately.*/ \
+                            execvp(shared_split_argv[0], (char * const*) shared_split_argv); \
+                        } \
+                    } \
                 } \
+                /* Unlike the normal exec, this must exit*/ \
+                /* immediately due to the setuid/setgid.  We don't*/ \
+                /* want unexpected commands running in an unexpected state.*/ \
+                stderrP("Failed to su-spawn "); \
+                stderrPLn(shared_split_argv[0]); \
+                _exit(1); \
+            } else { \
+                /* Else this is the parent process.*/ \
+                /* Just slurp up this argument.*/ \
+                /* Then, if the env is next, post the pid to that.*/ \
+                global_cmd = COMMAND_INDEX__SU_SPAWN__PID; \
             } \
-            /* Unlike the normal exec, this must exit*/ \
-            /* immediately due to the setuid/setgid.  We don't*/ \
-            /* want unexpected commands running in an unexpected state.*/ \
-            stderrP("Failed to su-spawn "); \
-            stderrPLn(shared_split_argv[0]); \
-            _exit(1); \
-        } else { \
-            /* Else this is the parent process.*/ \
-            /* Just slurp up this argument.*/ \
-            /* Then, if the env is next, post the pid to that.*/ \
-            global_cmd = COMMAND_INDEX__SU_SPAWN__PID; \
         } \
         break; \
     case COMMAND_INDEX__SU_SPAWN__PID: \
-        /* from cmd_su_spawn.h.in:130 */ \
-            /* from cmd_su_spawn.h.in:131 */ \
+        /* from cmd_su_spawn.h.in:135 */ \
+            /* from cmd_su_spawn.h.in:136 */ \
         /* Put the PID into the environment variable global_arg.*/ \
         /* This argument can only be run from the parent due to the logic above.*/ \
         global_itoa_ptr = shared_itoa(global_arg3_i, global_itoa); \


### PR DESCRIPTION
* The sub-argument parser did not include bounds check on the argument buffer. (#56)
* `exec`, `spawn`, `su-exec`, and `su-spawn` (commands that call the sub-argument parser) did not check the sub-argument call's error results.
* The `su-exec` and `su-spawn` did not drop secondary groups, leading to a leak in privilege. (#55)
